### PR TITLE
fix: correct workflow name syntax in auto booking YAML

### DIFF
--- a/.github/workflows/auto_booking.yaml
+++ b/.github/workflows/auto_booking.yaml
@@ -1,4 +1,5 @@
-name usyd-libcal-auto-booking
+name: usyd-libcal-auto-booking
+
 on:
   schedule:
     - cron: '30 14 * * *' # 00:30 GMT+10 01:30 GMT+11


### PR DESCRIPTION
Signed-off-by: yukuai0011 <kuyu5570@uni.sydney.edu.au>

## Summary by Sourcery

CI:
- Correct the syntax for the workflow name in the auto booking YAML file by adding a colon.