### PR TITLE
fix: add workflow_dispatch trigger to auto booking workflow

### DIFF
--- a/.github/workflows/auto_booking.yaml
+++ b/.github/workflows/auto_booking.yaml
@@ -3,6 +3,7 @@ name: usyd-libcal-auto-booking
 on:
   schedule:
     - cron: '30 14 * * *' # 00:30 GMT+10 01:30 GMT+11
+  workflow_dispatch:
 
 jobs:
   auto_booking:


### PR DESCRIPTION
Signed-off-by: yukuai0011 <kuyu5570@uni.sydney.edu.au>

## Summary by Sourcery

CI:
- Add workflow_dispatch trigger to the auto booking workflow to allow manual triggering of the workflow.