### PR TITLE
fix: update command to install Playwright in auto booking workflow

### DIFF
--- a/.github/workflows/auto_booking.yaml
+++ b/.github/workflows/auto_booking.yaml
@@ -31,6 +31,6 @@ jobs:
       - name: Run the script
         run: |
           uv sync
-          playwright install
+          uv run -m playwright install
           uv run auto_booking.py
 


### PR DESCRIPTION
Signed-off-by: yukuai0011 <kuyu5570@uni.sydney.edu.au>

## Summary by Sourcery

CI:
- Update the command to install Playwright in the auto booking workflow to use 'uv run -m playwright install' instead of 'playwright install'.