### PR TITLE
fix: correct script name in auto booking workflow

### DIFF
--- a/.github/workflows/auto_booking.yaml
+++ b/.github/workflows/auto_booking.yaml
@@ -32,5 +32,5 @@ jobs:
         run: |
           uv sync
           uv run -m playwright install
-          uv run auto_booking.py
+          uv run booking.py
 


### PR DESCRIPTION
Signed-off-by: yukuai0011 <kuyu5570@uni.sydney.edu.au>

## Summary by Sourcery

CI:
- Correct the script name from 'auto_booking.py' to 'booking.py' in the auto booking workflow configuration.