### PR TITLE
fix: correct typo in TOTP secret variable in auto booking workflow

### DIFF
--- a/.github/workflows/auto_booking.yaml
+++ b/.github/workflows/auto_booking.yaml
@@ -25,4 +25,4 @@ jobs:
         run: |
           uv sync
           uv run -m playwright install --with-deps
-          uv run booking.py --unikey ${{ secrets.UNIKEY }} --password ${{ secrets.UNI_PASSWORD }} --totp ${{ secrets.UNI_TOTP }}
+          uv run booking.py --unikey ${{ secrets.UNIKEY }} --password ${{ secrets.UNI_PASSWORD }} --totp ${{ secrets.UNI_TOPT_CODE }}


### PR DESCRIPTION
Signed-off-by: yukuai0011 <kuyu5570@uni.sydney.edu.au>

## Summary by Sourcery

Bug Fixes:
- Correct the typo in the TOTP secret variable name from 'UNI_TOTP' to 'UNI_TOPT_CODE' in the auto booking workflow.