### PR TITLE
fix: change booking seats JSON path argument to use double dashes for consistency

### DIFF
--- a/booking.py
+++ b/booking.py
@@ -12,7 +12,7 @@ parser.add_argument("--unikey", required=True, help="Your USYD Unikey")
 parser.add_argument("--password", required=True, help="Your USYD password")
 parser.add_argument("--totp", required=True, help="Your TOTP secret code")
 parser.add_argument(
-    "booking-seats-json-path",
+    "--booking-seats-json-path",
     required=True,
     help="Path to the JSON file containing the booking seats",
 )


### PR DESCRIPTION
Signed-off-by: yukuai0011 <kuyu5570@uni.sydney.edu.au>

## Summary by Sourcery

Bug Fixes:
- Change the booking seats JSON path argument to use double dashes for consistency with other command-line arguments.