### PR TITLE
rename var and add doc

### DIFF
--- a/.github/workflows/usyd-libcal-auto-booking.yaml
+++ b/.github/workflows/usyd-libcal-auto-booking.yaml
@@ -25,5 +25,5 @@ jobs:
         run: |
           uv sync
           uv run -m playwright install --with-deps
-          uv run booking.py --unikey ${{ secrets.UNIKEY }} --password ${{ secrets.UNI_PASSWORD }} --totp ${{ secrets.UNI_TOPT_CODE }} \
+          uv run booking.py --unikey ${{ secrets.UNIKEY }} --password ${{ secrets.UNI_PASSWORD }} --totp ${{ secrets.UNI_TOPT_SECRET }} \
           --booking-seats-json-path 'bookings.json'

--- a/.github/workflows/usyd-libcal-auto-booking.yaml
+++ b/.github/workflows/usyd-libcal-auto-booking.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  auto_booking_1:
+  auto_booking:
     runs-on: ubuntu-latest
     steps:
     # Step 1: Checkout the repository

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # usyd-libcal-auto-booking-public
 
+## Introduction
+
 Automatically book a study space at the University of Sydney Library using Playwright And Github Actions.
 
 
@@ -13,3 +15,53 @@ Desk 17 @ Law Library 10:00 - 16:00
 
 
 Execute at Sydney time 00:30, 01:30 if daylight saving.
+
+## How to use
+
+prepear the seats you want to book as the following format:
+
+```json
+{
+    "tasks": [
+        {
+            "num_days_from_now": 14,
+            "booking_page_url": "https://usyd.libcal.com/spaces?lid=3330&gid=0&c=0",
+            "seat_full_xpath": "/html/body/div[2]/main/div/div/div/div[3]/div[1]/div[2]/div/table/tbody/tr/td[3]/div/div/div/table/tbody/tr[10]/td/div/div[2]/div[23]/a/div/div/div"
+        },
+        {
+            "num_days_from_now": 14,
+            "booking_page_url": "https://usyd.libcal.com/spaces?lid=3331&gid=0&c=0",
+            "seat_full_xpath": "/html/body/div[2]/main/div/div/div/div[3]/div[1]/div[2]/div/table/tbody/tr/td[3]/div/div/div/table/tbody/tr[10]/td/div/div[2]/div[27]/a/div/div/div"
+        },
+        {
+            "num_days_from_now": 2,
+            "booking_page_url": "https://usyd.libcal.com/spaces?lid=3331&gid=0&c=0",
+            "seat_full_xpath": "/html/body/div[2]/main/div/div/div/div[3]/div[1]/div[2]/div/table/tbody/tr/td[3]/div/div/div/table/tbody/tr[28]/td/div/div[2]/div[21]/a/div/div/div"
+        },
+        {
+            "num_days_from_now": 2,
+            "booking_page_url": "https://usyd.libcal.com/spaces?lid=3331&gid=0&c=0",
+            "seat_full_xpath": "/html/body/div[2]/main/div/div/div/div[3]/div[1]/div[2]/div/table/tbody/tr/td[3]/div/div/div/table/tbody/tr[28]/td/div/div[2]/div[27]/a/div/div/div"
+        }
+    ]
+}
+```
+
+- `num_days_from_now`: The number of days from today to book the seat.
+- `booking_page_url`: The URL of the booking page.
+- `seat_full_xpath`: The XPath of the seat you want to book.
+
+To obtain the xpath, you can use the browser's developer tools. For example, in Chrome, you can right-click on the element and select "Copy" -> "Copy XPath".
+
+Then you can run the script by executing the following command:
+
+```bash
+uv sync 
+uv run -m playwright install --with-deps
+uv run booking.py --unikey <UNIKEY> --password <>UNI_PASSWORD> --totp $<>UNI_TOPT_CODE>
+--booking-seats-json-path <PATH_TO_JSON_FILE> 
+```
+
+Here the UNI_TOPT_CODE this is the code you can get by adding google authenticator to your okta account.
+
+Note this code here is not the 6 digit code you get from the google authenticator app, it is the code that generates the 6 digit code. In other words, it is the code embedded in the QR code when use sign up for the google authenticator app. Use bitwarden to scan the QR code can reveal the code. The code should be 16 characters long, all uppercase, with numbers and letters.

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ Then you can run the script by executing the following command:
 ```bash
 uv sync 
 uv run -m playwright install --with-deps
-uv run booking.py --unikey <UNIKEY> --password <>UNI_PASSWORD> --totp $<>UNI_TOPT_CODE>
+uv run booking.py --unikey <UNIKEY> --password <>UNI_PASSWORD> --totp $<>UNI_TOPT_SECERT>
 --booking-seats-json-path <PATH_TO_JSON_FILE> 
 ```
 
 Here the UNI_TOPT_CODE this is the code you can get by adding google authenticator to your okta account.
 
-Note this code here is not the 6 digit code you get from the google authenticator app, it is the code that generates the 6 digit code. In other words, it is the code embedded in the QR code when use sign up for the google authenticator app. Use bitwarden to scan the QR code can reveal the code. The code should be 16 characters long, all uppercase, with numbers and letters.
+Note this code here is not the 6 digit code you get from the google authenticator app, it is the secret that generates the 6 digit code. In other words, it is the code embedded in the QR code when use sign up for the google authenticator app. Use bitwarden to scan the QR code can reveal the code. The code should be 16 characters long, all uppercase, with numbers and letters.

--- a/booking.py
+++ b/booking.py
@@ -20,7 +20,7 @@ args = parser.parse_args()
 
 unikey = args.unikey
 uni_password = args.password
-uni_topt_code = args.totp
+uni_topt_secret = args.totp
 booking_seats_json_path = args.booking_seats_json_path
 
 with open(booking_seats_json_path, "r") as f:
@@ -95,7 +95,7 @@ with sync_playwright() as p:
         ).click()
         page.wait_for_timeout(1000)
         # calculate totp
-        totp = pyotp.TOTP(uni_topt_code)
+        totp = pyotp.TOTP(uni_topt_secret)
         page.locator(
             "xpath=/html/body/div[2]/main/div[2]/div/div/div[2]/form/div[1]/div[4]/div/div[2]/span/input"
         ).first.fill(totp.now())


### PR DESCRIPTION
Signed-off-by: yukuai0011 <kuyu5570@uni.sydney.edu.au>

## Summary by Sourcery

Enhance documentation by adding an introduction and usage instructions to the README. Improve code clarity by renaming variables related to TOTP secrets. Update the GitHub Actions workflow job name for better clarity.

Enhancements:
- Rename the variable 'uni_topt_code' to 'uni_topt_secret' for clarity and consistency in the codebase.

CI:
- Rename the job 'auto_booking_1' to 'auto_booking' in the GitHub Actions workflow for better clarity.

Documentation:
- Add an 'Introduction' section to the README to provide an overview of the project's purpose.
- Include a 'How to use' section in the README with detailed instructions on preparing booking tasks and running the script.