### PR TITLE
docs: update README to specify booking times for study spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Automatically book a study space at the University of Sydney Library using Playw
 
 It will book the following study spaces:
 
-Study room 202 @ Fisher Library 11:00 - 13:00
+Study room 202 @ Fisher Library 11:00 - 13:00, 14 days from now
 
-Study room M108 @ Law Library 13:00 - 15:00
+Study room M108 @ Law Library 13:00 - 15:00, 14 days from now
 
-Desk 17 @ Law Library 10:00 - 16:00
+Desk 17 @ Law Library 10:00 - 16:00, 2 days from now
 
 
 Execute at Sydney time 00:30, 01:30 if daylight saving.


### PR DESCRIPTION
Signed-off-by: yukuai0011 <kuyu5570@uni.sydney.edu.au>

## Summary by Sourcery

Documentation:
- Update README to specify the booking times for study spaces, indicating the number of days in advance each space is booked.