### PR TITLE
feat: change the excution time to 00:00 GMT +10:00

### DIFF
--- a/.github/workflows/usyd-libcal-auto-booking.yaml
+++ b/.github/workflows/usyd-libcal-auto-booking.yaml
@@ -2,7 +2,7 @@ name: usyd-libcal-auto-booking
 
 on:
   schedule:
-    - cron: '30 14 * * *' # 00:30 GMT+10 01:30 GMT+11
+    - cron: '00 14 * * *' # 00:30 GMT+10 01:30 GMT+11
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It will book the following study spaces:
 - Study room M108 @ Law Library 13:00 - 15:00, 14 days from now
 - Desk 17 @ Law Library 10:00 - 16:00, 2 days from now
 
-Execute at Sydney time 00:30, 01:30 if daylight saving.
+Execute at Sydney time 00:00, 01:00 if daylight saving.
 
 ## How to use
 


### PR DESCRIPTION
Signed-off-by: yukuai0011 <kuyu5570@uni.sydney.edu.au>

## Summary by Sourcery

Change the execution time for the usyd-libcal-auto-booking GitHub Actions workflow to 00:00 GMT+10:00 and update the README to reflect this change.

CI:
- Update the execution time in the GitHub Actions workflow to 00:00 GMT+10:00.

Documentation:
- Update the README to reflect the new execution time of 00:00 Sydney time, adjusting for daylight saving.