### PR TITLE
fix: clarify seat booking format in README to specify JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Execute at Sydney time 00:00, 01:00 if daylight saving.
 
 ## How to use
 
-prepear the seats you want to book as the following format:
+prepear the seats you want to book as a json file in the following format:
 
 ```json
 {


### PR DESCRIPTION
Signed-off-by: yukuai0011 <kuyu5570@uni.sydney.edu.au>

## Summary by Sourcery

Documentation:
- Clarify the seat booking format in the README to specify that it should be a JSON file.