### PR TITLE
fix: update cron schedule time to 00:00 GMT +10:00 in workflow configuration

### DIFF
--- a/.github/workflows/usyd-libcal-auto-booking.yaml
+++ b/.github/workflows/usyd-libcal-auto-booking.yaml
@@ -2,7 +2,7 @@ name: usyd-libcal-auto-booking
 
 on:
   schedule:
-    - cron: '00 14 * * *' # 00:30 GMT+10 01:30 GMT+11
+    - cron: '00 14 * * *' # 00:00 GMT+10 01:00 GMT+11
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Signed-off-by: yukuai0011 <kuyu5570@uni.sydney.edu.au>

## Summary by Sourcery

CI:
- Update the cron schedule time in the workflow configuration to 00:00 GMT+10:00.