### PR TITLE
fix: update `requires-python` to allow versions >=3.12 and <3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "usyd-libcal-auto-booking"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = "==3.12.*"
+requires-python = ">=3.12, <3.13"
 dependencies = ["playwright", "pyotp"]
 
 [tool.uv]


### PR DESCRIPTION
Signed-off-by: yukuai0011 <kuyu5570@uni.sydney.edu.au>